### PR TITLE
Improve Commit Message Generation Logic To Support Deepseek Response

### DIFF
--- a/ai_commit/app.py
+++ b/ai_commit/app.py
@@ -102,11 +102,19 @@ def generate_commit_message_local_model(staged_changes: str):
         print("✨ Generating commit message...")
         print("-" * 50 + "\n")
         commit_message = ""
+        capture = True  # Start capturing initially
         for chunk in stream:
             if chunk["done"] is False:
                 content = chunk["message"]["content"]
                 print(content, end="", flush=True)
-                commit_message += content
+                if "<think>" in content:
+                    capture = False
+                    continue
+                if "</think>" in content:
+                    capture = True
+                    continue
+                if capture:
+                    commit_message += content
 
         return commit_message
     except Exception as e:

--- a/ai_commit/prompts.py
+++ b/ai_commit/prompts.py
@@ -17,7 +17,7 @@ Key Guidelines:
 - Return just the commit message, no additional text
 - Don't return more bullet points than required
 
-Output Format:
+Output Format Should Contain:
 Concise Title Summarizing Changes
 
 - Specific change description


### PR DESCRIPTION
*   Update `generate_commit_message_local_model` to capture and append content which is out of the `<think>` tag.